### PR TITLE
Remove apt cache in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM php:8.4-fpm
 
 RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libfreetype6-dev && \
     docker-php-ext-configure gd --with-freetype --with-jpeg && \
-    docker-php-ext-install gd mysqli pdo_mysql
+    docker-php-ext-install gd mysqli pdo_mysql && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 


### PR DESCRIPTION
This adds `rm -rf /var/lib/apt/lists/*` to the Dockerfile to remove cached package lists after `apt-get install`, reducing image size. Since the image `php:8.4-fpm` is based off Debian bookworm (12), this is a common best practice for minimizing unnecessary bloat.